### PR TITLE
Merge pull request #1589 from notargs/feature/fix_uv_scroll_bug

### DIFF
--- a/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_input.hlsl
+++ b/Assets/VRMShaders/VRM10/MToon10/Resources/VRM10/vrmc_materials_mtoon_input.hlsl
@@ -12,7 +12,8 @@ UNITY_DECLARE_TEX2D(_EmissionMap);
 UNITY_DECLARE_TEX2D(_MatcapTex);
 UNITY_DECLARE_TEX2D(_RimTex);
 UNITY_DECLARE_TEX2D(_OutlineWidthTex);
-UNITY_DECLARE_TEX2D(_UvAnimMaskTex);
+// NOTE: "tex2d() * _Time.y" returns mediump value if sampler is half precision in Android VR platform
+UNITY_DECLARE_TEX2D_FLOAT(_UvAnimMaskTex);
 
 CBUFFER_START(UnityPerMaterial)
 // Vector
@@ -35,9 +36,9 @@ half _RimLift;
 half _RimLightingMix;
 half _OutlineWidth;
 half _OutlineLightingMix;
-half _UvAnimScrollXSpeed;
-half _UvAnimScrollYSpeed;
-half _UvAnimRotationSpeed;
+float _UvAnimScrollXSpeed;
+float _UvAnimScrollYSpeed;
+float _UvAnimRotationSpeed;
 CBUFFER_END
 
 // No Using on shader


### PR DESCRIPTION
#1589をcherry-pick

Questなどの一部端末で、一定時間経過後にMToonのテクスチャスクロールがカクカクする問題を修正